### PR TITLE
Show PKCE checkbox by default, remove noPkce attribute

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -229,11 +229,6 @@
           "type": "string | undefined"
         },
         {
-          "name": "noPkce",
-          "description": "When this property is set then the PKCE option is not rendered for the \n`authorization_code`. This is mainly meant to be used by the `api-authorization-method`\nto keep this control disabled and override generated settings when the API spec\nsays that the PKCE is supported.",
-          "type": "boolean | undefined"
-        },
-        {
           "name": "pkce",
           "description": "Whether or not the PKCE extension is enabled for this authorization configuration.\nNote, PKCE, per the spec, is only available for `authorization_code` grantType.",
           "type": "boolean"
@@ -578,12 +573,6 @@
           "name": "lastErrorMessage",
           "description": "The error message returned by the authorization library.\nIt renders error dialog when an error ocurred. \nIt is automatically cleared when the user request the token again.",
           "type": "string | undefined"
-        },
-        {
-          "name": "noPkce",
-          "attribute": "noPkce",
-          "description": "When this property is set then the PKCE option is not rendered for the \n`authorization_code`. This is mainly meant to be used by the `api-authorization-method`\nto keep this control disabled and override generated settings when the API spec\nsays that the PKCE is supported.",
-          "type": "boolean | undefined"
         },
         {
           "name": "pkce",

--- a/demo/demo-api/demo-api.raml
+++ b/demo/demo-api/demo-api.raml
@@ -155,6 +155,7 @@ securitySchemes:
   oauth2headerDelivery: !include oauth2-header-delivery.raml
   oauth2noDelivery: !include oauth2-no-delivery.raml
   oauth2noGrants: !include oauth2-no-grants.raml
+  oauth2pkce: !include oauth2-pkce.raml
   oauth1: !include oauth_1_0.raml
   oauth1signature: !include oauth_1_0_signature.raml
   oauth1noSignature: !include oauth_1_0_no-signature.raml
@@ -204,6 +205,9 @@ securitySchemes:
 /oauth2-no-grants:
   get:
     securedBy: [oauth2noGrants]
+/oauth2-pkce:
+  get:
+    securedBy: [oauth2pkce]
 /oauth1:
   get:
     securedBy: [oauth1]

--- a/demo/demo-api/oauth2-pkce.raml
+++ b/demo/demo-api/oauth2-pkce.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0 SecurityScheme
+type: OAuth 2.0
+displayName: This OAuth2 has PKCE annotation
+settings:
+  (pkce): true
+  accessTokenUri: https://token.com
+  authorizationUri: https://auth.com
+  scopes: [profile, email]
+describedBy:
+  queryParameters:
+    access_token:
+      type: string
+      description: Apply access token here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-authorization-method",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-authorization-method",
   "description": "An element to render an UI for various authorization methods with support of AMF data model for web APIs",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiOauth2MethodMixin.js
+++ b/src/ApiOauth2MethodMixin.js
@@ -91,11 +91,6 @@ const mxFunction = (base) => {
       return scheme;
     }
 
-    constructor() {
-      super();
-      this.noPkce = true;
-    }
-
     [initializeOauth2Model]() {
       const { security } = this;
       if (!this._hasType(security, this.ns.aml.vocabularies.security.ParametrizedSecurityScheme)) {

--- a/test/oauth2-method.test.js
+++ b/test/oauth2-method.test.js
@@ -147,6 +147,28 @@ describe('OAuth 2', () => {
           assert.isTrue(node.hasAttribute('hidden'));
         });
 
+        it('should not show pkce checkbox if selected grant type is not authorization_code', async () => {
+          const element = await modelFixture(amf, '/oauth2', 'post');
+          /* Default grant type selected is Access Token for this endpoint */
+          /* Check it just in case */
+          assert.equal(element.grantType, 'implicit');
+          const node = element.shadowRoot.querySelector('.adv-toggle anypoint-switch');
+          node.click();
+          await nextFrame();
+          const pkceCheckbox = element.shadowRoot.querySelector('.advanced-section').querySelector('anypoint-checkbox');
+          assert.notExists(pkceCheckbox);
+        });
+
+        it('should show pkce checkbox unchecked by default in advanced settings with authorization_code selected', async () => {
+          const element = await modelFixture(amf, '/oauth2', 'post');
+          element.grantType = 'authorization_code';
+          const node = element.shadowRoot.querySelector('.adv-toggle anypoint-switch');
+          node.click();
+          await nextFrame();
+          const pkceCheckbox = element.shadowRoot.querySelector('.advanced-section').querySelector('anypoint-checkbox');
+          assert.isFalse(pkceCheckbox.checked);
+        });
+
         it('does not render annotation inputs when are not defined', async () => {
           const element = await modelFixture(amf, '/oauth2', 'post');
           const node = element.shadowRoot.querySelector('.custom-data-field');
@@ -427,8 +449,7 @@ describe('OAuth 2', () => {
 
         it('restores configuration when grant type is selected', async () => {
           const security = AmfLoader.lookupSecurity(amf, '/pets', 'patch');
-          // @ts-ignore
-          const element = await basicFixture(amf);
+          element = await basicFixture(amf);
           element.grantType = 'authorization_code';
           await nextFrame();
           element.security = security;
@@ -507,10 +528,6 @@ describe('OAuth 2', () => {
 
         it('sets the `pkce` property to true', () => {
           assert.isTrue(element.pkce);
-        });
-
-        it('sets the `noPkce` property to true', () => {
-          assert.isTrue(element.noPkce);
         });
       });
     });


### PR DESCRIPTION
We should always should PKCE checkbox for Authorization Code grant type. Default value (checked/unchecked) depends on the information from the AMF model.